### PR TITLE
Update Client.php

### DIFF
--- a/src/League/ColorExtractor/Client.php
+++ b/src/League/ColorExtractor/Client.php
@@ -15,7 +15,7 @@ class Client
      */
     public function loadJpeg($imagePath)
     {
-        return new Image(imagecreatefromjpeg($imagePath));
+        return new Image(\imagecreatefromjpeg($imagePath));
     }
 
     /**
@@ -25,7 +25,7 @@ class Client
      */
     public function loadPng($imagePath)
     {
-        return new Image(imagecreatefrompng($imagePath));
+        return new Image(\imagecreatefrompng($imagePath));
     }
 
     /**
@@ -35,6 +35,6 @@ class Client
      */
     public function loadGif($imagePath)
     {
-        return new Image(imagecreatefromgif($imagePath));
+        return new Image(\imagecreatefromgif($imagePath));
     }
 }


### PR DESCRIPTION
On my PHP 5.5 environment this failed due to "Call to undefined function League\ColorExtractor\imagecreatefrompng()" - the GD functions which are in the global namespace were not properly referenced. Not sure how this ever managed to work in the first place?
