### PR TITLE
Update readme to mention GD support requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Via Composer
 $ composer require league/color-extractor:0.1.*
 ```
 
+Requires an installation of php that includes GD support. See [PHP.net documentation](http://php.net/manual/en/image.installation.php) for installation procedures. 
+
 ## Usage
 
 ```php


### PR DESCRIPTION
I had issues trying to use this library initially, because I didn't realize it was using GD manipulations under the hood, and by default my (and possibly most) php installations don't include GD support out of the box. 

I found the documentation and comments at http://php.net/manual/en/image.installation.php helpful in order to install `php5-gd` on my debian-based distro in order to use this library. 

Without GD support, errors occur such as: 

```
Call to undefined function League\ColorExtractor\imagecreatefrompng() in [...]/vendor/league/color-extractor/src/League/ColorExtractor/Client.php on line 14
```

In order to help others, I submit this README.md update comment referencing the php.net documentation. 
