### PR TITLE
Add getter for the image resource in Image class

### DIFF
--- a/src/League/ColorExtractor/Image.php
+++ b/src/League/ColorExtractor/Image.php
@@ -25,6 +25,14 @@ class Image
     {
         $this->imageResource = $imageResource;
     }
+    
+    /**
+     * @return resource
+     */
+    public function getImageResource()
+    {
+        return $this->imageResource;
+    }
 
     /**
      * @param $minColorRatio


### PR DESCRIPTION
I need to access the image resoruce later on. This just adds handy getter for it. The reason is there is no way I can use `imagedestroy()` without a valid resource.

Also, could we add a `Image::destroy()` method to call `imagedestroy()` from our code.