### PR TITLE
Switch to singleton method for Laravel 5.2 - change works fine in Laravel 5.1 too.

### DIFF
--- a/src/League/ColorExtractor/Laravel/ColorExtractorServiceProvider.php
+++ b/src/League/ColorExtractor/Laravel/ColorExtractorServiceProvider.php
@@ -24,7 +24,7 @@ class ColorExtractorServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bindShared('color-extractor', function ($app) {
+        $this->app->singleton('color-extractor', function ($app) {
             return new Client();
         });
 


### PR DESCRIPTION
Laravel 5.2 deprecates the bindShared method in favor of the singleton method (see http://laravel.com/docs/master/upgrade).