### PR TITLE
add Imagick support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,15 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "ext-gd": "*"
+        "php": ">=5.4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2",
         "phpunit/phpunit": "~5"
+    },
+    "suggest": {
+        "ext-gd": "to create palettes",
+        "ext-imagick": "to create palettes"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Fix #37 

Add creation method for Imagick and call it from `fromFilename` if the extension is loaded because it seems faster.

Since _ext-gd_ is no longer mandatory I moved it with _ext-imagick_ in composer.json `suggest` section.

I'm thinking this PR could introduce the 1.0.0 release. What do you think @GrahamCampbell @philsturgeon  @toin0u?
