### PR TITLE
If no interesting colours, return empty array

### DIFF
--- a/src/League/ColorExtractor/ColorExtractor.php
+++ b/src/League/ColorExtractor/ColorExtractor.php
@@ -75,6 +75,9 @@ class ColorExtractor
     protected static function mergeColors(\SplFixedArray $colors, $limit, $maxDelta)
     {
         $limit = min(count($colors), $limit);
+        if ($limit === 0) {
+            return [];
+        }
         if ($limit === 1) {
             return [$colors[0]];
         }


### PR DESCRIPTION
If $colors has zero elements, the "$labCache = new \SplFixedArray($limit - 1);" line will error while trying to create an array with -1 elements.