### PR TITLE
docs: remove dollar sign from installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Extract colors from an image like a human would do.
 Via Composer
 
 ``` bash
-$ composer require league/color-extractor
+composer require league/color-extractor
 ```
 
 ## Usage


### PR DESCRIPTION
If you copy and paste (using GitHub's copy to clipboard functionality) including the $, your shell will try to execute $ as a command (or interpret it as a variable), which will cause an error.