### PR TITLE
Fix failing CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,32 +6,33 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        php: [8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.4, 7.3]
+        php: ['8.5', '8.4', '8.3', '8.2', '8.1', '8.0', '7.4', '7.3']
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Cache dependencies
-        uses: actions/cache@v1
-        with:
-          path: ~/.composer/cache/files
-          key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+        uses: actions/checkout@v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.18.0
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: curl, zip, gd
           coverage: none
 
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/composer/files
+          key: dependencies-php-${{ matrix.php }}-${{ matrix.dependency-version }}-composer-${{ hashFiles('composer.json') }}
+          restore-keys: dependencies-php-${{ matrix.php }}-${{ matrix.dependency-version }}-composer-
+
       - name: Install dependencies
-        run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+        run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit


### PR DESCRIPTION
## Problem

Every job on `master` was failing within a few seconds:

> This request has been automatically failed because it uses a deprecated version of `actions/cache: v1`.

GitHub stopped serving `actions/cache@v1`, so the workflow died during action resolution — before checkout, before PHP setup, before a single test ran. The test suite itself was never the problem.

## Changes

- `actions/cache@v1` → `@v4` (the actual breakage)
- `actions/checkout@v2` → `@v4` — v2 runs on the retired Node 16 runtime
- `shivammathur/setup-php@2.18.0` → `@v2` — the pin was from 2021 and predates PHP 8.2+
- Corrected the cache path to Composer 2's location (`~/.cache/composer/files`; the old `~/.composer/cache/files` was a Composer 1 path and had been silently missing), and added the dependency-version to the cache key so `prefer-lowest` and `prefer-stable` no longer share an entry
- Dropped `--no-suggest`, which Composer 2 ignores and warns about
- Quoted the matrix PHP versions — YAML parsed `8.0` as a float and passed `8` to `setup-php`
- `fail-fast: false`, so one broken version reports instead of cancelling the other 15 jobs

## Verification

Full suite passes locally on PHP 8.5 against both `--prefer-stable` and `--prefer-lowest` (14 tests, 26 assertions). The remaining versions are covered by the matrix on this PR.