### PR TITLE
Move `ColorExtractor` tests to `ColorExtractTest`

### DIFF
--- a/tests/ColorExtractorTest.php
+++ b/tests/ColorExtractorTest.php
@@ -17,11 +17,9 @@ final class ColorExtractorTest extends TestCase
      */
     public function testExtract(string $imagePath, int $colorCount, array $expectedColors): void
     {
-        $palette = Palette::fromFilename($imagePath);
-        $extractor = new ColorExtractor($palette);
-        $colors = $extractor->extract($colorCount);
+        $extractor = new ColorExtractor(Palette::fromFilename($imagePath));
 
-        self::assertSame($expectedColors, $colors);
+        $this->assertSame($expectedColors, $extractor->extract($colorCount));
     }
 
     public function dataForTestExtract(): iterable
@@ -34,5 +32,10 @@ final class ColorExtractorTest extends TestCase
         yield [__DIR__.'/assets/google.png', 5, [18417, 15080241, 42259, 16360960, 4753405]];
         yield [__DIR__.'/assets/empty.png', 0, []];
         yield [__DIR__.'/assets/empty.png', 1, []];
+        yield [__DIR__.'/assets/test.jpeg', 1, [15985688]];
+        yield [__DIR__.'/assets/test.gif', 1, [12022491]];
+        yield [__DIR__.'/assets/test.png', 1, [14024704]];
+        yield [__DIR__.'/assets/test.png', 3, [14024704, 3407872, 7111569]];
+        yield [__DIR__.'/assets/test.webp', 1, [15008271]];
     }
 }

--- a/tests/PaletteTest.php
+++ b/tests/PaletteTest.php
@@ -5,77 +5,20 @@ declare(strict_types=1);
 namespace League\ColorExtractor\Tests;
 
 use League\ColorExtractor\Color;
-use League\ColorExtractor\ColorExtractor;
 use League\ColorExtractor\Palette;
 use PHPUnit\Framework\TestCase;
 
 class PaletteTest extends TestCase
 {
-    protected $jpegPath = __DIR__.'/assets/test.jpeg';
-    protected $gifPath = __DIR__.'/assets/test.gif';
-    protected $pngPath = __DIR__.'/assets/test.png';
-    protected $webpPath = __DIR__.'/assets/test.webp';
-    protected $transparentPngPath = __DIR__.'/assets/red-transparent-50.png';
-
-    public function testJpegExtractSingleColor(): void
-    {
-        $extractor = new ColorExtractor(Palette::fromFilename($this->jpegPath));
-        $colors = $extractor->extract(1);
-
-        $this->assertIsArray($colors);
-        $this->assertCount(1, $colors);
-        $this->assertEquals(15985688, $colors[0]);
-    }
-
-    public function testGifExtractSingleColor(): void
-    {
-        $extractor = new ColorExtractor(Palette::fromFilename($this->gifPath));
-        $colors = $extractor->extract(1);
-
-        $this->assertIsArray($colors);
-        $this->assertCount(1, $colors);
-        $this->assertEquals(12022491, $colors[0]);
-    }
-
-    public function testPngExtractSingleColor(): void
-    {
-        $extractor = new ColorExtractor(Palette::fromFilename($this->pngPath));
-        $colors = $extractor->extract(1);
-
-        $this->assertIsArray($colors);
-        $this->assertCount(1, $colors);
-        $this->assertEquals(14024704, $colors[0]);
-    }
-
-    public function testWebpExtractSingleColor(): void
-    {
-        $extractor = new ColorExtractor(Palette::fromFilename($this->webpPath));
-        $colors = $extractor->extract(1);
-
-        $this->assertIsArray($colors);
-        $this->assertCount(1, $colors);
-        $this->assertEquals(15008271, $colors[0]);
-    }
-
-    public function testJpegExtractMultipleColors(): void
-    {
-        $extractor = new ColorExtractor(Palette::fromFilename($this->pngPath));
-        $numColors = 3;
-        $colors = $extractor->extract($numColors);
-
-        $this->assertIsArray($colors);
-        $this->assertCount($numColors, $colors);
-        $this->assertEquals($colors, [14024704, 3407872, 7111569]);
-    }
-
     public function testTransparencyHandling(): void
     {
-        $this->assertCount(0, Palette::fromFilename($this->transparentPngPath));
+        $imagePath = __DIR__.'/assets/red-transparent-50.png';
+        $this->assertCount(0, Palette::fromFilename($imagePath));
 
-        $whiteBackgroundPalette = Palette::fromFilename($this->transparentPngPath, Color::fromHexToInt('#FFFFFF'));
-        $this->assertEquals(iterator_to_array($whiteBackgroundPalette), [Color::fromHexToInt('#FF8080') => 1]);
+        $whiteBackgroundPalette = Palette::fromFilename($imagePath, Color::fromHexToInt('#FFFFFF'));
+        $this->assertSame([Color::fromHexToInt('#FF8080') => 1], iterator_to_array($whiteBackgroundPalette));
 
-        $blackBackgroundPalette = Palette::fromFilename($this->transparentPngPath, Color::fromHexToInt('#000000'));
-        $this->assertEquals(iterator_to_array($blackBackgroundPalette), [Color::fromHexToInt('#7E0000') => 1]);
+        $blackBackgroundPalette = Palette::fromFilename($imagePath, Color::fromHexToInt('#000000'));
+        $this->assertSame([Color::fromHexToInt('#7E0000') => 1], iterator_to_array($blackBackgroundPalette));
     }
 }


### PR DESCRIPTION
Most of `PaletteTest` tests actually tested the `ColorExtractor` :thinking: those are moved to `ColorExtractTest`.