### PR TITLE
Drop support for PHP 7.3

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -23,14 +23,14 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
-          php-version: 7.3
+          php-version: 7.4
           coverage: none
 
       - name: Install PHP-CS-Fixer
         run: composer install --working-dir=tools/php-cs-fixer
 
       - name: Run PHP-CS-Fixer
-        run: vendor/bin/php-cs-fixer fix --dry-run --stop-on-violation --using-cache=no
+        run: vendor/bin/php-cs-fixer check -v --show-progress=dots --stop-on-violation --using-cache=no
 
   phpstan:
     runs-on: ubuntu-latest
@@ -46,7 +46,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
-          php-version: 7.3
+          php-version: 7.4
           coverage: none
 
       - name: Install PHPStan

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.5', '8.4', '8.3', '8.2', '8.1', '8.0', '7.4', '7.3']
+        php: ['8.5', '8.4', '8.3', '8.2', '8.1', '8.0', '7.4']
 
     name: PHP ${{ matrix.php }}
 

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -9,8 +9,8 @@ return (new PhpCsFixer\Config())
     ->setFinder($finder)
     ->setRiskyAllowed(true)
     ->setRules([
-        '@PHP71Migration:risky' => true,
-        '@PHP73Migration' => true,
+        '@PHP7x4Migration' => true,
+        '@PHP7x4Migration:risky' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,20 +2,20 @@
 
 Contributions are **welcome** and will be fully **credited**.
 
-We accept contributions via Pull Requests on [Github](https://github.com/php-loep/statsd).
+We accept contributions via Pull Requests on [GitHub](https://github.com/thephpleague/color-extractor/pulls).
 
 
 ## Pull Requests
 
-- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+- **Coding Standard** - Run `composer -dtools/php-cs-fixer install` and `vendor/bin/php-cs-fixer fix -vvv` to make your code conform.
 
-- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
+- **Add tests!** - Your patch won’t be accepted if it doesn’t have tests.
 
 - **Document any change in behaviour** - Make sure the README and any other relevant documentation are kept up-to-date.
 
 - **Consider our release cycle** - We try to follow semver. Randomly breaking public APIs is not an option.
 
-- **Create topic branches** - Don't ask us to pull from your master branch.
+- **Create topic branches** - Don’t ask us to pull from your master branch.
 
 - **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
 
@@ -24,9 +24,26 @@ We accept contributions via Pull Requests on [Github](https://github.com/php-loe
 
 ## Running Tests
 
-``` bash
-$ phpunit
+First install PHPUnit:
+
+```bash
+composer -dtools/phpunit install
 ```
+
+Then generate the codebase autoloader if it doesn’t already exist:
+
+```bash
+composer dump-autoload
+```
+
+You’re now ready to run tests:
+
+```bash
+vendor/bin/phpunit
+```
+
+Some tests may be skipped if you don’t have the required extensions installed.
+Don’t worry though: the CI will run them all.
 
 
 **Happy coding**!

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ use League\ColorExtractor\Color;
 use League\ColorExtractor\ColorExtractor;
 use League\ColorExtractor\Palette;
 
+// this will load the image using GD
 $palette = Palette::fromFilename('./some/image.png');
+
+// you can use Imagick if you prefer
+// $palette = Palette::fromImagick(new \Imagick('./some/image.png'));
 
 // $palette is an iterator on colors sorted by pixel count
 foreach($palette as $color => $count) {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "suggest": {
         "ext-curl": "To download images from remote URLs if allow_url_fopen is disabled for security reasons",

--- a/src/Color.php
+++ b/src/Color.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace League\ColorExtractor;
 
 /**
@@ -15,7 +13,7 @@ class Color
      */
     public static function fromIntToHex(int $color, bool $prependHash = true): string
     {
-        return ($prependHash ? '#' : '').sprintf('%06X', $color);
+        return ($prependHash ? '#' : '').\sprintf('%06X', $color);
     }
 
     /**
@@ -51,6 +49,6 @@ class Color
      */
     public static function fromRgbToInt(array $components): int
     {
-        return ($components['r'] * 65536) + ($components['g'] * 256) + ($components['b']);
+        return ($components['r'] * 65536) + ($components['g'] * 256) + $components['b'];
     }
 }

--- a/src/ColorExtractor.php
+++ b/src/ColorExtractor.php
@@ -1,53 +1,25 @@
 <?php
 
-declare(strict_types=1);
-
 namespace League\ColorExtractor;
 
 /**
  * @phpstan-import-type IntColor from Color
+ *
  * @phpstan-type LabColor array{L: float, a: float, b: float}
  */
 class ColorExtractor
 {
-    /** @var Palette */
-    protected $palette;
+    protected Palette $palette;
 
     /** @var \SplFixedArray<IntColor> */
-    protected $sortedColors;
+    protected \SplFixedArray $sortedColors;
 
     public function __construct(Palette $palette)
     {
         $this->palette = $palette;
-    }
-
-    /**
-     * @param int<0, max> $colorCount
-     *
-     * @return list<IntColor>
-     */
-    public function extract(int $colorCount = 1): array
-    {
-        if (0 === $colorCount) {
-            return [];
-        }
-
-        if (!$this->isInitialized()) {
-            $this->initialize();
-        }
-
-        return self::mergeColors($this->sortedColors, $colorCount, 100 / $colorCount);
-    }
-
-    protected function isInitialized(): bool
-    {
-        return null !== $this->sortedColors;
-    }
-
-    protected function initialize(): void
-    {
-        $queue = new \SplPriorityQueue();
         $this->sortedColors = new \SplFixedArray(\count($this->palette));
+
+        $queue = new \SplPriorityQueue();
 
         $i = 0;
         foreach ($this->palette as $color => $count) {
@@ -67,6 +39,20 @@ class ColorExtractor
             $queue->next();
             ++$i;
         }
+    }
+
+    /**
+     * @param int<0, max> $colorCount
+     *
+     * @return list<IntColor>
+     */
+    public function extract(int $colorCount = 1): array
+    {
+        if (0 > $colorCount) {
+            throw new \DomainException('$colorCount must be positive.');
+        }
+
+        return $colorCount ? self::mergeColors($this->sortedColors, $colorCount, 100 / $colorCount) : [];
     }
 
     /**
@@ -96,6 +82,7 @@ class ColorExtractor
             $colorLab = self::intColorToLab($color);
 
             foreach ($mergedColors as $i => $mergedColor) {
+                // @phpstan-ignore argument.type ($labCache[$i] is guaranteed to be a LabColor)
                 if (self::ciede2000DeltaE($colorLab, $labCache[$i]) < $maxDelta) {
                     $hasColorBeenMerged = true;
                     break;
@@ -266,7 +253,7 @@ class ColorExtractor
      */
     protected static function xyzToLab(array $xyz): array
     {
-        //http://en.wikipedia.org/wiki/Illuminant_D65#Definition
+        // http://en.wikipedia.org/wiki/Illuminant_D65#Definition
         $Xn = .95047;
         $Yn = 1;
         $Zn = 1.08883;

--- a/src/Palette.php
+++ b/src/Palette.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace League\ColorExtractor;
 
 /**
@@ -12,7 +10,7 @@ namespace League\ColorExtractor;
 class Palette implements \Countable, \IteratorAggregate
 {
     /** @var array<IntColor, positive-int> */
-    protected $colors = [];
+    protected array $colors = [];
 
     #[\ReturnTypeWillChange]
     public function count(): int
@@ -51,24 +49,25 @@ class Palette implements \Countable, \IteratorAggregate
     public static function fromFilename(string $filename, ?int $backgroundColor = null): self
     {
         if (!\extension_loaded('gd')) {
-            throw new \LogicException(sprintf('"%s()" requires the "gd" extension, enable it or call "fromImagick()" instead.', __METHOD__));
+            throw new \LogicException(\sprintf('"%s()" requires the "gd" extension, enable it or call "fromImagick()" instead.', __METHOD__));
         }
 
         $contents = @file_get_contents($filename);
         if (false === $contents) {
-            throw new \InvalidArgumentException(sprintf('Failed to read "%s"', $filename));
+            throw new \InvalidArgumentException(\sprintf('Failed to read "%s"', $filename));
         }
 
         return self::fromContents($contents, $backgroundColor);
     }
 
     /**
-     * @param ?IntColor $backgroundColor
+     * @param non-empty-string $url
+     * @param ?IntColor        $backgroundColor
      */
     public static function fromUrl(string $url, ?int $backgroundColor = null): self
     {
         if (!\extension_loaded('gd')) {
-            throw new \LogicException(sprintf('"%s()" requires the "gd" extension, enable it or call "fromImagick()" instead.', __METHOD__));
+            throw new \LogicException(\sprintf('"%s()" requires the "gd" extension, enable it or call "fromImagick()" instead.', __METHOD__));
         }
 
         if (!\function_exists('curl_init')) {
@@ -98,7 +97,7 @@ class Palette implements \Countable, \IteratorAggregate
     public static function fromContents(string $contents, ?int $backgroundColor = null): self
     {
         if (!\extension_loaded('gd')) {
-            throw new \LogicException(sprintf('"%s()" requires the "gd" extension, enable it or call "fromImagick()" instead.', __METHOD__));
+            throw new \LogicException(\sprintf('"%s()" requires the "gd" extension, enable it or call "fromImagick()" instead.', __METHOD__));
         }
 
         $image = imagecreatefromstring($contents);
@@ -125,7 +124,7 @@ class Palette implements \Countable, \IteratorAggregate
             throw new \InvalidArgumentException('Image must be a gd resource');
         }
         if (null !== $backgroundColor && ($backgroundColor < 0 || $backgroundColor > 16777215)) {
-            throw new \InvalidArgumentException(sprintf('"%s" does not represent a valid color', $backgroundColor));
+            throw new \InvalidArgumentException(\sprintf('"%s" does not represent a valid color', $backgroundColor));
         }
 
         $palette = new self();
@@ -142,14 +141,14 @@ class Palette implements \Countable, \IteratorAggregate
             for ($y = 0; $y < $imageHeight; ++$y) {
                 $color = imagecolorat($image, $x, $y);
                 if (false === $color) {
-                    throw new \RuntimeException(sprintf('Failed to get color at %d, %d', $x, $y));
+                    throw new \RuntimeException(\sprintf('Failed to get color at %d, %d', $x, $y));
                 }
                 if ($areColorsIndexed) {
                     $colorComponents = imagecolorsforindex($image, $color);
                     $color = ($colorComponents['alpha'] * 16777216) +
                              ($colorComponents['red'] * 65536) +
                              ($colorComponents['green'] * 256) +
-                             ($colorComponents['blue']);
+                             $colorComponents['blue'];
                 }
 
                 if ($transparency = $color >> 24) {
@@ -179,7 +178,7 @@ class Palette implements \Countable, \IteratorAggregate
     public static function fromImagick(\Imagick $image, ?int $backgroundColor = null): self
     {
         if (null !== $backgroundColor && ($backgroundColor < 0 || $backgroundColor > 16777215)) {
-            throw new \InvalidArgumentException(sprintf('"%s" does not represent a valid color', $backgroundColor));
+            throw new \InvalidArgumentException(\sprintf('"%s" does not represent a valid color', $backgroundColor));
         }
 
         $palette = new self();

--- a/tests/ColorExtractorTest.php
+++ b/tests/ColorExtractorTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace League\ColorExtractor\Tests;
 
 use League\ColorExtractor\ColorExtractor;
@@ -32,6 +30,15 @@ final class ColorExtractorTest extends TestCase
         $extractor = new ColorExtractor(Palette::fromImagick(new \Imagick($imagePath)));
 
         $this->assertSame($expectedColors, $extractor->extract($colorCount));
+    }
+
+    public function testNegativeColorCountCannotBeExtracted(): void
+    {
+        $extractor = new ColorExtractor($this->createStub(Palette::class));
+
+        $this->expectException(\DomainException::class);
+
+        $extractor->extract(-1);
     }
 
     public function dataForTestExtract(): iterable

--- a/tests/PaletteTest.php
+++ b/tests/PaletteTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace League\ColorExtractor\Tests;
 
 use League\ColorExtractor\Color;

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "3.4.0"
+        "friendsofphp/php-cs-fixer": "3.95.23"
     },
     "config": {
         "bin-dir": "../../vendor/bin",

--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpstan/phpstan": "1.12.34"
+        "phpstan/phpstan": "2.2.9"
     },
     "config": {
         "bin-dir": "../../vendor/bin",


### PR DESCRIPTION
This doesn’t change much given how small the codebase is, but we can now use typed properties and update PHP-CS-Fixer and PHPStan to their latest version (PHPUnit 10 requires `"php": ">=8.0"`).